### PR TITLE
fix incorrect calculation of ee_region and improve effiency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ tags
 [._]*.un~
 
 .DS_Store
+
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "c:\\Users\\yangz\\Dropbox\\Codes\\ITensorEntropyTools.jl"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "c:\\Users\\yangz\\Dropbox\\Codes\\ITensorEntropyTools.jl"
+}

--- a/src/entropy_calc.jl
+++ b/src/entropy_calc.jl
@@ -45,7 +45,13 @@ function ee_region(
     return ee_bipartite(ψ, region[end]; ee_type, verbose, kwargs...)
   elseif mode == "auto" && (region == collect(region[1]:length(ψ)))
     verbose && println("Using bipartite calculation for region $region")
-    return ee_bipartite(ψ, region[1]; ee_type, verbose, kwargs...)
+    return ee_bipartite(ψ, region[1]-1; ee_type, verbose, kwargs...)
+  end
+
+  # check if complement of the region is connected
+  region_C = setdiff(1:length(ψ), region)
+  if Set(region_C) == Set(minimum(region_C):maximum(region_C))
+    region = region_C
   end
 
   ρ = density_matrix_region(ψ, region; mode, verbose, kwargs...)

--- a/test/test_entropy.jl
+++ b/test/test_entropy.jl
@@ -42,4 +42,15 @@ seed!(42)
       end
     end
   end
+
+  @testset "Complement region equivalence" begin
+    s = siteinds(2, 10)
+    psi = random_mps(s; linkdims=4)
+
+    for i in 1:9
+      ee_left = ee_region(psi, 1:i)
+      ee_right = ee_region(psi, (i + 1):10)
+      @test ee_left ≈ ee_right
+    end
+  end
 end


### PR DESCRIPTION
Hi Ryan,

Thank you for writing this wonderful package. Just some small fixes here.

Let psi be an MPS of length 10. We should have
`ee_region(psi, 5:10)==ee_region(psi, 1:4) `
But instead, the function actually does,
`ee_region(psi, 5:10) == ee_region(psi, 1:5)` 
which is incorrect.

Moreover, when calculating a region whose complement is a connected region in the middle, e.g.
`ee_region(psi, vcat(1:3, 7:10))`
it is more efficient to calculate the complement region ee,
`ee_region(psi, 4:6)`

I have modified the function ee_region for these two improvements. 

Best, Zhou